### PR TITLE
Add colors for barbar.nvim

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Plugins explicity styled
 - [fzf.vim](https://github.com/junegunn/fzf.vim)
 - [indentLine](https://github.com/Yggdroot/indentLine) (please set `let g:indentLine_setColors = 0` in your _vimrc_)
 - [vimfiler](https://github.com/Shougo/vimfiler.vim)
+- [barbar.nvim](https://github.com/romgrk/barbar.nvim)
 
 Installation
 ------------

--- a/colors/nightfly.vim
+++ b/colors/nightfly.vim
@@ -851,3 +851,14 @@ exec 'highlight User4 guibg=' . s:watermelon . ' guifg=' . s:dark_blue
 exec 'highlight User5 guibg=' . s:slate_blue . ' guifg=' . s:blue       . ' gui=none'
 exec 'highlight User6 guibg=' . s:slate_blue . ' guifg=' . s:watermelon . ' gui=none'
 exec 'highlight User7 guibg=' . s:slate_blue . ' guifg=' . s:blue       . ' gui=none'
+
+" barbar.nvim
+exec 'highlight BufferCurrent      guibg=' . s:dark_blue . '  guifg=' . s:white
+exec 'highlight BufferCurrentMod   guibg=' . s:dark_blue . '  guifg=' . s:tan
+exec 'highlight BufferCurrentSign  guibg=' . s:dark_blue . '  guifg=' . s:blue
+exec 'highlight BufferVisible      guibg=' . s:dark_blue . '  guifg=' . s:grey_blue
+exec 'highlight BufferVisibleMod   guibg=' . s:dark_blue . '  guifg=' . s:tan
+exec 'highlight BufferVisibleSign  guibg=' . s:dark_blue . '  guifg=' . s:grey_blue
+exec 'highlight BufferInactive     guibg=' . s:slate_blue . ' guifg=' . s:grey_blue
+exec 'highlight BufferInactiveMod  guibg=' . s:slate_blue . ' guifg=' . s:tan
+exec 'highlight BufferInactiveSign guibg=' . s:slate_blue . ' guifg=' . s:cadet_blue


### PR DESCRIPTION
<img width="1016" alt="grafik" src="https://user-images.githubusercontent.com/310624/100080717-762a3c80-2e46-11eb-9624-51dcdb8c68ae.png">

As discussed in #11, these colors fit the original style of [barbar.nvim](https://github.com/romgrk/barbar.nvim) while still staying reasonably true to nightfly. There is still an issue with the file type icon background being not correct, but I hardly notice this when working, so I don't think it should hold off a PR. I'll open an issue in the barbar.nvim repo about this (if I don't forget again 🙈).

I've been using these for over a week now and didn't notice any issues with the colors themselves.

Sorry for taking so long!

Fixes #11 