### PR TITLE
fix: prevent nvim headless error at startup

### DIFF
--- a/colors/nightfly.vim
+++ b/colors/nightfly.vim
@@ -17,7 +17,7 @@ let g:colors_name='nightfly'
 "
 " If running in a terminal make sure termguicolors exists and is set.
 if has('nvim')
-    if has('nvim-0.4') && nvim_list_uis()[0]['ext_termcolors'] && !&termguicolors
+    if has('nvim-0.4') && list(nvim_list_uis()) > 0 && nvim_list_uis()[0]['ext_termcolors'] && !&termguicolors
         " The nvim_list_uis test indicates terminal Neovim vs GUI Neovim.
         " Note, versions prior to Neovim 0.4 did not set 'ext_termcolors'.
         echomsg 'The termguicolors option must be set'


### PR DESCRIPTION
Hi,
We encounted an issue with vim-nightfly-guicolors here jbyuki/one-small-step-for-vimkind#3 in the case neovim is started in headless mode with the vim-nightfly-guicolors colorscheme set.  vim-nightfly-guicolors throws an error at startup because it's trying to fetch ui informations but there isn't one in headless. This PR should fix the issue.