### PR TITLE
Allow hiding VertSplit

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,14 @@ following to your configuration:
 let g:nightflyNormalFloat = 1
 ```
 
+The `g:nightflyVertSplits` option specifies whether to show vertical panel
+separators. By default they will be visible, setting it to 0 will make them 
+the same color as the background.
+
+```viml
+let g:nightflyVertSplits = 0
+```
+
 :bulb: If the above option is set then it is highly recommended to enable
 floating window borders to distinguish between the edit and floating windows in
 Neovim's LSP client, for example:

--- a/colors/nightfly.vim
+++ b/colors/nightfly.vim
@@ -56,6 +56,9 @@ let g:nightflyTransparent = get(g:, 'nightflyTransparent', 0)
 " floating windows).
 let g:nightflyNormalFloat = get(g:, 'nightflyNormalFloat', 0)
 
+" By default display panel separators
+let g:nightflyVertSplits = get(g:, 'nightflyVertSplits', 1)
+
 " Background and foreground
 let s:black      = '#011627'
 let s:white      = '#c3ccdc'
@@ -222,12 +225,17 @@ highlight! link Structure NightflyIndigo
 " Status, split and tab lines
 exec 'highlight StatusLine cterm=none guibg=' . s:slate_blue . ' guifg=' . s:white . ' gui=none'
 exec 'highlight StatusLineNC cterm=none guibg=' . s:slate_blue . ' guifg=' . s:cadet_blue . ' gui=none'
-exec 'highlight VertSplit cterm=none guibg=' . s:slate_blue . ' guifg=' . s:slate_blue . ' gui=none'
 exec 'highlight Tabline cterm=none guibg=' . s:slate_blue . ' guifg=' . s:cadet_blue . ' gui=none'
 exec 'highlight TablineSel cterm=none guibg=' . s:slate_blue . ' guifg=' . s:blue . ' gui=none'
 exec 'highlight TablineFill cterm=none guibg=' . s:slate_blue . ' guifg=' . s:slate_blue . ' gui=none'
 exec 'highlight StatusLineTerm cterm=none guibg=' . s:slate_blue . ' guifg=' . s:white . ' gui=none'
 exec 'highlight StatusLineTermNC cterm=none guibg=' . s:slate_blue . ' guifg=' . s:cadet_blue . ' gui=none'
+
+if g:nightflyVertSplits
+  exec 'highlight VertSplit cterm=none guibg=' . s:slate_blue . ' guifg=' . s:slate_blue . ' gui=none'
+else
+  exec 'highlight VertSplit cterm=none guibg=' . s:black . ' guifg=' . s:black . ' gui=none'
+end
 
 " Visual selection
 exec 'highlight Visual guibg=' . s:regal_blue


### PR DESCRIPTION
Adds an option to hide the vertical split separators

```
vim.g.nightflyPanelSeparators = 0
```
![Screenshot from 2021-08-07 20-12-01](https://user-images.githubusercontent.com/62089/128610147-0748e906-f5f4-404d-bd77-d01e1b3baef8.png)

```
vim.g.nightflyPanelSeparators = 1
```
![Screenshot from 2021-08-07 20-10-14](https://user-images.githubusercontent.com/62089/128610148-ec9b64f7-134b-4aae-900d-655e5abd9e61.png)


