### PR TITLE
Add explicit support for 'mini.nvim'

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Neovim-only:
 - [Hop](https://github.com/phaazon/hop.nvim)
 - [Indent BlankLine](https://github.com/lukas-reineke/indent-blankline.nvim)
 - [Lualine](https://github.com/nvim-lualine/lualine.nvim)
+- [Mini](https://github.com/echasnovski/mini.nvim)
 - [Neo-tree](https://github.com/nvim-neo-tree/neo-tree.nvim)
 - [nvim-cmp](https://github.com/hrsh7th/nvim-cmp)
 - [NvimTree](https://github.com/kyazdani42/nvim-tree.lua)

--- a/colors/nightfly.vim
+++ b/colors/nightfly.vim
@@ -1058,6 +1058,57 @@ if has('nvim')
     exec 'highlight IndentBlanklineChar guifg=' . s:deep_blue  . ' gui=nocombine'
     exec 'highlight IndentBlanklineSpaceChar guifg=' . s:deep_blue  . ' gui=nocombine'
     exec 'highlight IndentBlanklineSpaceCharBlankline guifg=' . s:deep_blue  . ' gui=nocombine'
+
+    " Mini
+    highlight! link MiniCompletionActiveParameter NightflyVisual
+
+    highlight MiniCursorword gui=underline
+    highlight MiniCursorwordCurrent gui=underline
+
+    highlight! link MiniIndentscopeSymbol NightflyWhite
+    highlight MiniIndentscopePrefix gui=nocombine
+
+    highlight! link MiniJump SpellRare
+
+    exec 'highlight MiniJump2dSpot guifg=' . s:yellow . ' gui=bold,nocombine'
+
+    highlight MiniStarterCurrent gui=nocombine
+    highlight! link MiniStarterFooter Title
+    highlight! link MiniStarterHeader Title
+    highlight! link MiniStarterInactive Comment
+    highlight! link MiniStarterItem Normal
+    highlight! link MiniStarterItemBullet Delimiter
+    highlight! link MiniStarterItemPrefix NightflyYellow
+    highlight! link MiniStarterSection NightflyWatermelon
+    highlight! link MiniStarterQuery NightflyBlue
+
+    exec 'highlight MiniStatuslineDevinfo     guibg=' . s:regal_blue
+    exec 'highlight MiniStatuslineFileinfo    guibg=' . s:regal_blue
+    exec 'highlight MiniStatuslineFilename    guibg=' . s:slate_blue . ' guifg=' . s:white
+    exec 'highlight MiniStatuslineInactive    guibg=' . s:slate_blue . ' guifg=' . s:cadet_blue
+    exec 'highlight MiniStatuslineModeCommand guibg=' . s:yellow     . ' guifg=' . s:dark_blue . ' gui=bold'
+    exec 'highlight MiniStatuslineModeInsert  guibg=' . s:white      . ' guifg=' . s:dark_blue . ' gui=bold'
+    exec 'highlight MiniStatuslineModeNormal  guibg=' . s:blue       . ' guifg=' . s:dark_blue . ' gui=bold'
+    exec 'highlight MiniStatuslineModeOther   guibg=' . s:turquoise  . ' guifg=' . s:dark_blue . ' gui=bold'
+    exec 'highlight MiniStatuslineModeReplace guibg=' . s:watermelon . ' guifg=' . s:dark_blue . ' gui=bold'
+    exec 'highlight MiniStatuslineModeVisual  guibg=' . s:purple     . ' guifg=' . s:dark_blue . ' gui=bold'
+
+    highlight! link MiniSurround IncSearch
+
+    exec 'highlight MiniTablineCurrent         guibg=' . s:dark_blue  . ' guifg=' . s:white
+    highlight! link MiniTablineFill TabLineFill
+    exec 'highlight MiniTablineHidden          guibg=' . s:slate_blue . ' guifg=' . s:grey_blue
+    exec 'highlight MiniTablineModifiedCurrent guibg=' . s:dark_blue  . ' guifg=' . s:tan
+    exec 'highlight MiniTablineModifiedHidden  guibg=' . s:slate_blue . ' guifg=' . s:tan
+    exec 'highlight MiniTablineModifiedVisible guibg=' . s:dark_blue  . ' guifg=' . s:tan
+    exec 'highlight MiniTablineTabpagesection  guibg=' . s:black      . ' guifg=' . s:orange . ' gui=reverse,bold'
+    exec 'highlight MiniTablineVisible         guibg=' . s:dark_blue  . ' guifg=' . s:grey_blue
+
+    exec 'highlight MiniTestEmphasis gui=bold'
+    exec 'highlight MiniTestFail guifg=' . s:red  . ' gui=bold'
+    exec 'highlight MiniTestPass guifg=' . s:green  . ' gui=bold'
+
+    exec 'highlight MiniTrailspace guibg=' . s:red
 endif
 
 set background=dark


### PR DESCRIPTION
Hi! I would like to add explicit support for [mini.nvim](https://github.com/echasnovski/mini.nvim).

Basic choices are taken from highlight groups to which 'mini.nvim' makes links by default or from analogous plugins.

Differences from default linked groups:
- 'mini.completion' highlight of signature active parameter is based on `LspSignatureActiveParameter`.
- 'mini.jump2d' is based on 'Hop'. Added 'bold' to make it more visible and 'nocombine' to be consistent (not italic on italic text).
- 'mini.starter' is mostly links and based on personal choices:
    - `MiniStarterItemPrefix` and `MiniStarterQuery` are based on "warning" and "info" diagnostic colors to be opposite of each other.
    - `MiniStarterSection` is chosen to be visible.
- 'mini.statusline' is based on 'lualine/themes/nightfly.lua', `Mistfly*` highlight groups and personal choices:
    - `MiniStatuslineDevinfo` and `MiniStatuslineFileinfo` have slightly different background.
    - `MiniStatuslineModeCommand` and `MiniStatuslineModeOther` are chosen to be different.
- 'mini.tabline' is based on 'Barbar':
    - `MiniTablineTabpagesection` is chosen from `Search` but with bold style to be visible.
- 'mini.test' has red for fail and green for pass.
- 'mini.trailspace' has group with red background to draw attention.

Before:

https://user-images.githubusercontent.com/24854248/177970626-7dde02bc-358b-4bae-9172-568aa2326171.mp4

After:

https://user-images.githubusercontent.com/24854248/177970689-0ad0f910-454a-4429-8236-fcbe87711d8b.mp4