### PR TITLE
Add Windows Terminal config

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,6 +359,10 @@ A collection of _nightfly_-flavoured terminal themes are provided:
   [this](terminal_themes/alacritty.yml) theme into their `alacritty.yml`
   configuration.
 
+- [Windows Terminal](https://github.com/microsoft/terminal) users can copy
+  [this](terminal_themes/windows-terminal-settings.json) theme into their `settings.json`
+  configuration.
+
 - [kitty](https://sw.kovidgoyal.net/kitty) users can use
   [this](terminal_themes/kitty-theme.conf) theme
 

--- a/terminal_themes/windows-terminal-settings.json
+++ b/terminal_themes/windows-terminal-settings.json
@@ -1,0 +1,29 @@
+{
+    "$schema": "https://aka.ms/terminal-profiles-schema",
+    "schemes":
+    [
+        {
+            "name": "nightfly",
+            "background": "#011627",
+            "foreground": "#acb4c2",
+            "cursorColor": "#9ca1aa",
+            "selectionBackground": "#b2ceee",
+            "black": "#1d3b53",
+            "red": "#fc514e",
+            "green": "#a1cd5e",
+            "yellow": "#e3d18a",
+            "blue": "#82aaff",
+            "purple": "#c792ea",
+            "cyan": "#7fdbca",
+            "white": "#a1aab8",
+            "brightBlack": "#7c8f8f",
+            "brightRed": "#ff5874",
+            "brightGreen": "#21c7a8",
+            "brightYellow": "#ecc48d",
+            "brightBlue": "#82aaff",
+            "brightPurple": "#ae81ff",
+            "brightCyan": "#7fdbca",
+            "brightWhite": "#d6deeb"
+        }
+    ]
+}


### PR DESCRIPTION
For Windows Terminal users, I added a color scheme that can be used by copying it into their settings.json.

If there are no problems with this PR, I will send a PR to moonfly as well.